### PR TITLE
Fix #191: For iframe pages in a container, better iframe height adjustment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 - Enh #200: Removed CActiveForm, CHtml usages.
 - Enh #198: Avoid creating notifications on custom page creation
 - Enh #196: Footer menu pages
+- Fix #191: For iframe pages in a container, better iframe height adjustment
+
 
 1.4.3 (June 18, 2021)
 ---------------------

--- a/views/container/iframe.php
+++ b/views/container/iframe.php
@@ -1,10 +1,12 @@
 <?php
+
 use humhub\libs\Html;
 
 $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page->cssClass : 'custom-pages-page';
 ?>
 
-<iframe class="<?= Html::encode($cssClass) ?>" id="iframepage" style="width:100%; height: 100%;" src="<?= Html::encode($url); ?>"></iframe>
+<iframe class="<?= Html::encode($cssClass) ?>" id="iframepage" style="width:100%; height: 100%; min-height: 400px;"
+        src="<?= Html::encode($url); ?>"></iframe>
 
 <style>
     #iframepage {
@@ -17,7 +19,7 @@ $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page
 <?= Html::script(<<<JS
     function setSize() {
         $('#iframepage').css( {
-            height: (window.innerHeight - $('#iframepage').position().top - 15) + 'px',
+            height: ($(window).height() - $('#layout-content').position().top - 15) + 'px',
             background: 'inherit'
         });
     }


### PR DESCRIPTION
Fix #191: For iframe pages in a container, define the iframe height to be equal to the screen minus the topbar and 15px for the footer, with a minimum height of 400px.