### PR TITLE
Fix undefined PeopleHeadingButtons for v1.10

### DIFF
--- a/config.php
+++ b/config.php
@@ -9,7 +9,6 @@ use humhub\modules\space\widgets\Sidebar as SpaceSidebar;
 use humhub\modules\user\widgets\AccountMenu;
 use humhub\modules\admin\widgets\AdminMenu;
 use humhub\modules\user\widgets\AccountTopMenu;
-use humhub\modules\user\widgets\PeopleHeadingButtons;
 use humhub\widgets\BaseMenu;
 use humhub\widgets\FooterMenu;
 use humhub\widgets\TopMenu;
@@ -34,7 +33,7 @@ return [
         ['class' => Menu::class, 'event' => Menu::EVENT_INIT, 'callback' => [Events::class, 'onSpaceMenuInit']],
         ['class' => AccountTopMenu::class, 'event' => AccountTopMenu::EVENT_INIT, 'callback' => [Events::class, 'onAccountTopMenuInit']],
         ['class' => FooterMenu::class, 'event' => FooterMenu::EVENT_INIT, 'callback' => [Events::class, 'onFooterMenuInit']],
-        ['class' => PeopleHeadingButtons::class, 'event' => PeopleHeadingButtons::EVENT_INIT, 'callback' => [Events::class, 'onPeopleHeadingButtonsInit']],
+        ['class' => 'humhub\modules\user\widgets\PeopleHeadingButtons', 'event' => 'init', 'callback' => [Events::class, 'onPeopleHeadingButtonsInit']],
 
         ['class' => HeaderControlsMenu::class, 'event' => BaseMenu::EVENT_INIT, 'callback' => [Events::class, 'onSpaceAdminMenuInit']],
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.7.1 (July 12. 2022)
+--------------------
+- Fix #227: Fix using of `PeopleHeadingButtons` for old versions
+
 1.7.0 (July 7. 2022)
 --------------------
 - Fix #223: Deleting attached files from template pages was broken 

--- a/models/Page.php
+++ b/models/Page.php
@@ -150,13 +150,18 @@ class Page extends CustomContentContainer
      */
     public static function getDefaultTargets()
     {
-        return [
+        $targets = [
             ['id' => self::NAV_CLASS_TOPNAV, 'name' => Yii::t('CustomPagesModule.base', 'Top Navigation')],
             ['id' => self::NAV_CLASS_ACCOUNTNAV, 'name' => Yii::t('CustomPagesModule.base', 'User Account Menu (Settings)'), 'subLayout' => '@humhub/modules/user/views/account/_layout'],
             ['id' => self::NAV_CLASS_EMPTY, 'name' => Yii::t('CustomPagesModule.base', 'Without adding to navigation (Direct link)')],
             ['id' => self::NAV_CLASS_FOOTER, 'name' => Yii::t('CustomPagesModule.base', 'Footer menu')],
-            ['id' => self::NAV_CLASS_PEOPLE, 'name' => Yii::t('CustomPagesModule.base', 'People Buttons')],
         ];
+
+        if (class_exists('humhub\modules\user\widgets\PeopleHeadingButtons')) {
+            $targets[] = ['id' => self::NAV_CLASS_PEOPLE, 'name' => Yii::t('CustomPagesModule.base', 'People Buttons')];
+        }
+
+        return $targets;
     }
 
     /**

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Allows admins to create custom pages (html or markdown) or external links to various navigations (e.g. top navigation, account menu).",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.7.0",
+    "version": "1.7.1",
     "homepage": "https://github.com/humhub/custom-pages",
     "humhub": {
         "minVersion": "1.10"


### PR DESCRIPTION
Fix error: Class `humhub\modules\user\widgets\PeopleHeadingButtons` not found in `/modules/custom_pages/config.php:37`