### PR TITLE
Fix #244: Add markdown-render class to Markdown text for Translator m…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+-------------------------
+- Fix #244: Add markdown-render class to Markdown text for Translator module to work
+
 1.8.4 (September 9, 2022)
 -------------------------
 - Fix #241: Fix access to view HTML pages

--- a/views/container/markdown.php
+++ b/views/container/markdown.php
@@ -1,12 +1,13 @@
 <?php
 
+use humhub\modules\content\widgets\richtext\RichText;
 use humhub\modules\custom_pages\modules\template\widgets\PageConfigurationButton;
 use humhub\modules\custom_pages\widgets\CustomPageInlineStyle;
 use yii\helpers\Html;
-use humhub\modules\content\widgets\richtext\RichText;
+
 /** @var $page \humhub\modules\custom_pages\models\Page */
 
-$cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page->cssClass :  'custom-pages-page';
+$cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page->cssClass : 'custom-pages-page';
 ?>
 
 <?= CustomPageInlineStyle::widget(['theme' => $this->theme]); ?>
@@ -14,6 +15,8 @@ $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page
 <?= PageConfigurationButton::widget() ?>
 <div class="panel panel-default <?= Html::encode($cssClass) ?>">
     <div class="panel-body">
-        <?= RichText::output($md)?>
+        <div class="markdown-render">
+            <?= RichText::output($md) ?>
+        </div>
     </div>
 </div>

--- a/views/global/markdown.php
+++ b/views/global/markdown.php
@@ -1,12 +1,12 @@
 <?php
 
-use humhub\modules\custom_pages\models\Page;
-use humhub\modules\content\widgets\richtext\RichText;
 use humhub\libs\Html;
+use humhub\modules\content\widgets\richtext\RichText;
+use humhub\modules\custom_pages\models\Page;
 use humhub\modules\custom_pages\modules\template\widgets\PageConfigurationButton;
 use humhub\modules\custom_pages\widgets\CustomPageInlineStyle;
 
-/* @var $page Page*/
+/* @var $page Page */
 
 $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page->cssClass : 'custom-pages-page';
 ?>
@@ -17,7 +17,9 @@ $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page
     <div class="panel panel-default <?= Html::encode($cssClass) ?>">
         <div class="panel-body">
             <?= PageConfigurationButton::widget() ?>
-            <?= RichText::output($md)?>
+            <div class="markdown-render">
+                <?= RichText::output($md) ?>
+            </div>
         </div>
     </div>
 <?php else: ?>
@@ -27,7 +29,9 @@ $cssClass = ($page->hasAttribute('cssClass') && !empty($page->cssClass)) ? $page
                 <?= PageConfigurationButton::widget() ?>
                 <div class="panel panel-default">
                     <div class="panel-body">
-                        <?= RichText::output($md)?>
+                        <div class="markdown-render">
+                            <?= RichText::output($md) ?>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fix #244: Add markdown-render class to Markdown text for Translator module to work

Caution: another PR (https://github.com/humhub/custom-pages/pull/243) has another version of the README.md
If both PR are accepted, they should be merged.