### PR TITLE
Fix compatible `AssetVariable::offsetGet()` between different PHP versions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Fix #261: Add list buttons in toolbar of RichText TinyMCE editor
 - Fix #263: Conflicts if a page in a content container has the same ID as a global page
 - Fix #270: Don't wrap page type 
+- Fix #271: Fix compatible `AssetVariable::offsetGet()` between different PHP versions
 
 1.8.9 (February 6, 2023)
 ------------------------

--- a/modules/template/models/AssetVariablePhp74.php
+++ b/modules/template/models/AssetVariablePhp74.php
@@ -10,9 +10,9 @@ use Yii;
  * A OwnerContent instance is used to assign a TemplateElement to a specific
  * Content of a specific type.
  *
- * @warning Compatible only with PHP8.0+, Don't use for PHP versions <= 7.4!
+ * @deprecated Use this only for PHP7.4 and older versions
  */
-class AssetVariable implements \ArrayAccess
+class AssetVariablePhp74 implements \ArrayAccess
 {
     
     private $module;
@@ -46,7 +46,7 @@ class AssetVariable implements \ArrayAccess
         return true;
     }
 
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->get($offset);
     }

--- a/modules/template/models/Template.php
+++ b/modules/template/models/Template.php
@@ -207,7 +207,7 @@ class Template extends ActiveRecord implements TemplateContentOwner
             $content[$contentElement->element_name] = new OwnerContentVariable(['ownerContent' => $contentElement, 'options' => $options]);
         }
 
-        $content['assets'] = new AssetVariable();
+        $content['assets'] = PHP_VERSION_ID >= 80000 ? new AssetVariable() : new AssetVariablePhp74();
 
         if($containerItem) {
             //$content['item'] = new ContainerItemVariable(['item' => $containerItem]);


### PR DESCRIPTION
- on PHP 7.4 we can use only `public function offsetGet($offset)`, otherwise error on `: mixed`
- but PHP 8.1+ requires only `public function offsetGet($offset): mixed` otherwise error without `: mixed`