### PR TITLE
Fix visibility of attached images to default content of template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.10.14 (Unreleased)
+--------------------------
+- Fix #394: Fix visibility of attached images to default content of template
+
 1.10.13 (January 16, 2025)
 --------------------------
 - Fix #374: Fix allowed properties for Twig v3.14.1+

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Create custom pages and widgets and share them with your users. Take advantage of a wide range of editing options, including HTML and Markdown.",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.10.13",
+    "version": "1.10.14",
     "homepage": "https://github.com/humhub/custom-pages",
     "humhub": {
         "minVersion": "1.16"

--- a/modules/template/models/TemplateContentActiveRecord.php
+++ b/modules/template/models/TemplateContentActiveRecord.php
@@ -375,9 +375,9 @@ abstract class TemplateContentActiveRecord extends ActiveRecord implements Viewa
         }
 
         if ($customContentContainer === null && $this->getOwner() instanceof Template) {
-            // If this template content record is not linked to any container(Page, Snippet),
-            // then it is from Template Layout, try to check if the user can manage Template Layouts
-            return (new PermissionManager(['subject' => $user]))->can(ManagePages::class);
+            // It is a default content of the Template, and it is not linked to any container(Page, Snippet) yet,
+            // we cannot check a permission here, so we should allow everyone to view such content.
+            return true;
         }
 
         return false;


### PR DESCRIPTION
https://github.com/humhub/custom-pages-internal/issues/38