### PR TITLE
Register container resources(CSS & JS)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.11.0-beta.14 (Unreleased)
+-----------------------------------
+- Fix #469: Register container resources(CSS & JS)
+
 1.11.0-beta.13 (September 17, 2025)
 -----------------------------------
 - Enh #433: Change template overview

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Create custom pages and widgets and share them with your users. Take advantage of a wide range of editing options, including HTML and Markdown.",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.11.0-beta.13",
+    "version": "1.11.0-beta.14",
     "homepage": "https://github.com/humhub/custom-pages",
     "humhub": {
         "minVersion": "1.17"

--- a/modules/template/models/Template.php
+++ b/modules/template/models/Template.php
@@ -297,6 +297,8 @@ class Template extends ActiveRecord
      */
     public function render(?TemplateInstance $templateInstance = null)
     {
+        $this->registerResources();
+
         $result = '';
 
         if (TemplateInstanceRendererService::inEditMode() && $templateInstance && $templateInstance->isPage()) {

--- a/modules/template/services/TemplateInstanceRendererService.php
+++ b/modules/template/services/TemplateInstanceRendererService.php
@@ -63,8 +63,6 @@ class TemplateInstanceRendererService
      */
     public function render(): string
     {
-        $this->templateInstance->template->registerResources();
-
         if (self::inEditMode() && PagePermissionHelper::canEdit($this->templateInstance->page)) {
             $this->ignoreCache();
         }


### PR DESCRIPTION
Resources from Container were not registered.

Source:
<img width="855" height="1320" alt="source-container" src="https://github.com/user-attachments/assets/54347eec-da64-432d-8d15-4b8fa59c7e64" />

Before fix:
<img width="1106" height="534" alt="before-fix" src="https://github.com/user-attachments/assets/f1b0b12a-9e30-413a-8fa3-571d3d4a8c2b" />

After fix:
<img width="1124" height="535" alt="after-fix" src="https://github.com/user-attachments/assets/857fa662-5f98-43ad-ae5c-8b052bfc5b4e" />