### PR TITLE
Allow `id` and `data-*` attributes for Html template elements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 1.12.19 (Unreleased)
 ----------------------
-- Fix #532: Don't strip attributes from Html template elements (render unpurified, like Html type pages)
+- Fix #532: Allow `id` and `data-*` attributes for Html template elements
 
 1.12.18 (July 8, 2026)
 ----------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.12.19 (Unreleased)
+----------------------
+- Fix #532: Don't strip attributes from Html template elements (render unpurified, like Html type pages)
+
 1.12.18 (July 8, 2026)
 ----------------------
 - Fix #520: Display "Edit Page" button for global HTML pages

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Create custom pages and widgets and share them with your users. Take advantage of a wide range of editing options, including HTML and Markdown.",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.12.18",
+    "version": "1.12.19",
     "homepage": "https://github.com/humhub/custom-pages",
     "humhub": {
         "minVersion": "1.18.1",

--- a/modules/template/elements/BaseElementContent.php
+++ b/modules/template/elements/BaseElementContent.php
@@ -12,12 +12,14 @@ use humhub\interfaces\ViewableInterface;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\custom_pages\models\CustomPage;
 use humhub\modules\custom_pages\modules\template\components\ActiveRecordDynamicAttributes;
+use humhub\modules\custom_pages\modules\template\helpers\DataAttributeTransform;
 use humhub\modules\custom_pages\modules\template\helpers\PagePermissionHelper;
 use humhub\modules\custom_pages\modules\template\models\TemplateElement;
 use humhub\modules\custom_pages\modules\template\models\TemplateInstance;
 use humhub\widgets\form\ActiveForm;
 use Yii;
 use yii\db\ActiveQuery;
+use yii\helpers\HtmlPurifier;
 
 /**
  * This is the base class for all Template Element Content types.
@@ -307,11 +309,20 @@ abstract class BaseElementContent extends ActiveRecordDynamicAttributes implemen
 
     public function purify($content)
     {
-        $config = \HTMLPurifier_Config::createDefault();
-        $config->set('HTML.Attr.Name.UseCDATA', true);
-        $config->set('Attr.AllowedFrameTargets', ['_blank']);
+        return HtmlPurifier::process($content, function ($config): void {
+            /* @var \HTMLPurifier_Config $config */
+            $config->set('HTML.Attr.Name.UseCDATA', true);
+            $config->set('Attr.AllowedFrameTargets', ['_blank']);
 
-        return \yii\helpers\HtmlPurifier::process($content, $config);
+            // Allow `id` attributes (needed e.g. for anchor/TOC navigation)
+            $config->set('Attr.EnableID', true);
+
+            // Allow `data-*` attributes (not whitelisted by HTMLPurifier by default)
+            $definition = $config->getHTMLDefinition(true);
+            $dataAttributeTransform = new DataAttributeTransform();
+            $definition->info_attr_transform_pre[] = $dataAttributeTransform;
+            $definition->info_attr_transform_post[] = $dataAttributeTransform;
+        });
     }
 
 

--- a/modules/template/elements/HtmlElement.php
+++ b/modules/template/elements/HtmlElement.php
@@ -64,10 +64,16 @@ class HtmlElement extends BaseElementContent implements \Stringable
 
     /**
      * @inheritdoc
+     *
+     * Note: Unlike other template elements, the Html element intentionally renders its
+     * content unpurified - same as page content of a Custom Page with type Html
+     * (@see \humhub\modules\custom_pages\models\CustomPage::getPageContent()). Script
+     * nonces are applied afterwards by TemplateInstanceRendererService::render(), which
+     * wraps the whole rendered template output, same as for Html type pages.
      */
     public function __toString(): string
     {
-        return (string) $this->purify($this->content);
+        return (string) $this->content;
     }
 
     /**

--- a/modules/template/elements/HtmlElement.php
+++ b/modules/template/elements/HtmlElement.php
@@ -64,16 +64,10 @@ class HtmlElement extends BaseElementContent implements \Stringable
 
     /**
      * @inheritdoc
-     *
-     * Note: Unlike other template elements, the Html element intentionally renders its
-     * content unpurified - same as page content of a Custom Page with type Html
-     * (@see \humhub\modules\custom_pages\models\CustomPage::getPageContent()). Script
-     * nonces are applied afterwards by TemplateInstanceRendererService::render(), which
-     * wraps the whole rendered template output, same as for Html type pages.
      */
     public function __toString(): string
     {
-        return (string) $this->content;
+        return (string) $this->purify($this->content);
     }
 
     /**

--- a/modules/template/helpers/DataAttributeTransform.php
+++ b/modules/template/helpers/DataAttributeTransform.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\custom_pages\modules\template\helpers;
+
+use HTMLPurifier_AttrTransform;
+
+/**
+ * HTMLPurifier by default has no notion of `data-*` attributes, so they get
+ * stripped by the attribute whitelist like any other unknown attribute.
+ *
+ * This transform is registered both as a pre- and as a post- attribute
+ * transform (see {@see BaseElementContent::purify()}). On the pre-pass (run
+ * before whitelist validation) it stashes away any `data-*` attribute in the
+ * current context. On the post-pass (run after whitelist validation, once
+ * the stash already exists) it merges the stashed attributes back in, since
+ * by then they would otherwise have already been removed for not being on
+ * the whitelist.
+ */
+class DataAttributeTransform extends HTMLPurifier_AttrTransform
+{
+    private const CONTEXT_KEY = 'CustomPagesDataAttributeStash';
+
+    /**
+     * @inheritdoc
+     */
+    public function transform($attr, $config, $context)
+    {
+        if ($context->exists(self::CONTEXT_KEY)) {
+            // Post-pass: restore the data-* attributes stashed in the pre-pass
+            $stash = $context->get(self::CONTEXT_KEY);
+            foreach ($stash as $name => $value) {
+                $attr[$name] = $value;
+            }
+            $context->destroy(self::CONTEXT_KEY);
+
+            return $attr;
+        }
+
+        // Pre-pass: stash away data-* attributes so they survive whitelist validation.
+        // Values containing `<` or `>` are dropped: HTMLPurifier's output escaping only
+        // protects the HTML document itself, not what a browser hands back to JS reading
+        // the attribute (e.g. via `.dataset`/`.data()`), which is HTML-entity-decoded
+        // again. Disallowing angle brackets in the value prevents it from ever looking
+        // like markup again, even if some script naively inserts it via `.html()`.
+        $stash = [];
+        foreach ($attr as $name => $value) {
+            if (is_string($name)
+                && is_string($value)
+                && preg_match('/^data-[a-z0-9-]+$/i', $name)
+                && strpbrk($value, '<>') === false
+            ) {
+                $stash[$name] = $value;
+            }
+        }
+        $context->register(self::CONTEXT_KEY, $stash);
+
+        return $attr;
+    }
+}


### PR DESCRIPTION
https://github.com/humhub/humhub-internal/issues/1255