### PR TITLE
Don't import "created" and "updated" data of files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.12.20 (Unreleased)
+-----------------------
+- Fix #534: Don't import "created" and "updated" data of files
+
 1.12.19 (July 16, 2026)
 -----------------------
 - Fix #532: Allow `id` and `data-*` attributes for Html template elements

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Custom Pages",
     "description": "Create custom pages and widgets and share them with your users. Take advantage of a wide range of editing options, including HTML and Markdown.",
     "keywords": ["pages", "custom", "iframe", "markdown", "link", "navigation", "spaces"],
-    "version": "1.12.19",
+    "version": "1.12.20",
     "homepage": "https://github.com/humhub/custom-pages",
     "humhub": {
         "minVersion": "1.18.1",

--- a/modules/template/services/BaseImportService.php
+++ b/modules/template/services/BaseImportService.php
@@ -53,6 +53,7 @@ abstract class BaseImportService
     {
         $updateRecord = false;
 
+        $skipAttributes = ['guid', 'object_model', 'object_id', 'created_by', 'created_at', 'updated_by', 'updated_at'];
         $newFiles = [];
         foreach ($files as $fileData) {
             $file = new FileContent();
@@ -60,7 +61,7 @@ abstract class BaseImportService
                 if ($attribute === 'base64Content') {
                     $file->newFileContent = base64_decode((string) $value);
                 }
-                if (!in_array($attribute, ['guid', 'object_model', 'object_id']) && $file->hasAttribute($attribute)) {
+                if (!in_array($attribute, $skipAttributes) && $file->hasAttribute($attribute)) {
                     $file->$attribute = $value;
                 }
             }


### PR DESCRIPTION
To avoid the error on import when user doesn't exist in DB with ID from the importing file:

SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`humhub_develop`.`file`, CONSTRAINT `fk_file-created_by` FOREIGN KEY (`created_by`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE)\nThe SQL being executed was: INSERT INTO `file` (`state`, `category`, `sort_order`, `content_id`, `file_name`, `title`, `mime_type`, `size`, `created_at`, `created_by`, `updated_at`, ...",