### PR TITLE
Add read-only custom pages REST API with rendered content

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -249,6 +249,20 @@ class Events
         }
     }
 
+    public static function onRestApiAddRules()
+    {
+        /* @var \humhub\modules\rest\Module $restModule */
+        $restModule = Yii::$app->getModule('rest');
+        $restModule->addRules([
+
+            ['pattern' => 'custom-pages', 'route' => 'custom_pages/rest/custom-page/find', 'verb' => ['GET', 'HEAD']],
+            ['pattern' => 'custom-pages/global', 'route' => 'custom_pages/rest/custom-page/find-global', 'verb' => ['GET', 'HEAD']],
+            ['pattern' => 'custom-pages/container/<containerId:\\d+>', 'route' => 'custom_pages/rest/custom-page/find-by-container', 'verb' => ['GET', 'HEAD']],
+            ['pattern' => 'custom-pages/page/<id:\\d+>', 'route' => 'custom_pages/rest/custom-page/view', 'verb' => ['GET', 'HEAD']],
+
+        ], 'custom-pages');
+    }
+
     public static function onDashboardSidebarInit($event)
     {
         try {

--- a/config.php
+++ b/config.php
@@ -41,5 +41,6 @@ return [
 
         ['class' => DashboardSidebar::class, 'event' => DashboardSidebar::EVENT_INIT, 'callback' => [Events::class, 'onDashboardSidebarInit']],
         ['class' => SpaceSidebar::class, 'event' => SpaceSidebar::EVENT_INIT, 'callback' => [Events::class, 'onSpaceSidebarInit']],
+        ['class' => 'humhub\\modules\\rest\\Module', 'event' => 'restApiAddRules', 'callback' => [Events::class, 'onRestApiAddRules']],
     ],
 ];

--- a/controllers/rest/CustomPageController.php
+++ b/controllers/rest/CustomPageController.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\custom_pages\controllers\rest;
+
+use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\content\models\Content;
+use humhub\modules\custom_pages\helpers\RestDefinitions;
+use humhub\modules\custom_pages\models\CustomPage;
+use humhub\modules\rest\components\BaseContentController;
+use Yii;
+
+class CustomPageController extends BaseContentController
+{
+    public static $moduleId = 'custom_pages';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentActiveRecordClass()
+    {
+        return CustomPage::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function returnContentDefinition(ContentActiveRecord $contentRecord)
+    {
+        /** @var CustomPage $contentRecord */
+        return RestDefinitions::getCustomPage($contentRecord);
+    }
+
+    public function actionFind()
+    {
+        $contentContainerId = Yii::$app->request->get('contentcontainer_id');
+
+        if ($contentContainerId !== null) {
+            if (!ctype_digit((string)$contentContainerId)) {
+                return $this->returnError(400, 'Invalid contentcontainer_id parameter.');
+            }
+        }
+
+        return $this->findCustomPages($contentContainerId === null ? null : (int)$contentContainerId);
+    }
+
+    public function actionFindGlobal()
+    {
+        return $this->findCustomPages(0);
+    }
+
+    private function findCustomPages(?int $contentContainerId = null)
+    {
+        $query = CustomPage::find()->joinWith('content')->orderBy(['content.created_at' => SORT_DESC])->readable();
+
+        if ($contentContainerId !== null) {
+            $query->andWhere([Content::tableName() . '.contentcontainer_id' => $contentContainerId ?: null]);
+        }
+
+        $pagination = $this->handlePagination($query);
+
+        $results = [];
+        foreach ($query->all() as $contentRecord) {
+            $results[] = $this->returnContentDefinition($contentRecord);
+        }
+
+        return $this->returnPagination($query, $pagination, $results);
+    }
+
+    public function actionCreate($containerId)
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionCreateGlobal()
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionUpdate($id)
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionDelete($id)
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionDeleteByContainer($containerId)
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionAttachFiles($id)
+    {
+        return $this->notAllowed();
+    }
+
+    public function actionRemoveFile($id, $fileId)
+    {
+        return $this->notAllowed();
+    }
+
+    private function notAllowed()
+    {
+        return $this->returnError(405, 'Method not allowed. Read-only endpoint.');
+    }
+}

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -1,0 +1,61 @@
+# Custom Pages REST API
+
+Readonly REST API for custom pages
+
+## Endpoints
+
+### Get all Custom Pages
+
+- Method: GET
+- Path: `/api/v1/custom-pages`
+- Global Custom Pages: `/api/v1/custom-pages?contentcontainer_id=0`
+- Alias for global Custom Pages: `/api/v1/custom-pages/global`
+
+### Get Custom Pages by container
+
+- Method: GET
+- Path: `/api/v1/custom-pages/container/{containerId}`
+
+### Get a specific Custom Page
+
+- Method: GET
+- Path: `/api/v1/custom-pages/page/{id}`
+
+## Example-Request
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" \
+  "https://example.org/api/v1/custom-pages/page/123"
+```
+
+## Example-Response
+
+```json
+{
+  "id": 123,
+  "title": "My custom page",
+  "type": 2,
+  "target": "SpaceMenu",
+  "icon": "fa-file-text-o",
+  "sort_order": 100,
+  "in_new_window": false,
+  "url": "my-custom-page",
+  "abstract": "Short description",
+  "cssClass": "team-page",
+  "page_content": "# Raw content",
+  "rendered_content": "<h1>Rendered content</h1><p>… as displayed…</p>",
+  "text_content": "Rendered content… as displayed…",
+  "visibility": 1,
+  "hide_menu": false,
+  "page_type": "page",
+  "template_id": 0,
+  "page_url": "https://example.org/s/space/custom_pages/view?id=123",
+  "permalink": "https://example.org/content/perma?id=999",
+  "content": {
+    "id": 999,
+    "guid": "…",
+    "created_at": "2026-08-31 10:00:00"
+  }
+}
+```
+

--- a/helpers/RestDefinitions.php
+++ b/helpers/RestDefinitions.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace humhub\modules\custom_pages\helpers;
+
+use humhub\modules\custom_pages\models\CustomPage;
+use humhub\modules\rest\definitions\ContentDefinitions;
+use Throwable;
+use Yii;
+use yii\helpers\Url;
+
+class RestDefinitions
+{
+    public static function getCustomPage(CustomPage $page): array
+    {
+        $renderedContent = static::getRenderedContent($page);
+
+        return [
+            'id' => $page->id,
+            'title' => $page->title,
+            'type' => $page->type,
+            'target' => $page->target,
+            'icon' => $page->icon,
+            'sort_order' => $page->sort_order,
+            'in_new_window' => (bool)$page->in_new_window,
+            'url' => $page->url,
+            'abstract' => $page->abstract,
+            'cssClass' => $page->cssClass,
+            'page_content' => $page->page_content,
+            'rendered_content' => $renderedContent,
+            'text_content' => static::getTextContent($renderedContent),
+            'visibility' => $page->visibility,
+            'hide_menu' => (bool)$page->hide_menu,
+            'page_type' => $page->getPageType(),
+            'template_id' => $page->getTemplateId(),
+            'page_url' => $page->getUrl(),
+            'permalink' => static::getPagePermalink($page),
+            'content' => ContentDefinitions::getContent($page->content),
+        ];
+    }
+
+    public static function getPagePermalink(CustomPage $page): string
+    {
+        return Url::to(['/content/perma', 'id' => $page->content->id], true);
+    }
+
+    private static function getRenderedContent(CustomPage $page): ?string
+    {
+        try {
+            return $page->render();
+        } catch (Throwable $e) {
+            Yii::error($e);
+            return null;
+        }
+    }
+
+    private static function getTextContent(?string $renderedContent): ?string
+    {
+        if ($renderedContent === null) {
+            return null;
+        }
+
+        $text = html_entity_decode(strip_tags($renderedContent), ENT_QUOTES | ENT_HTML5, Yii::$app->charset);
+        $normalizedText = preg_replace('/[\r\n\s]+/u', ' ', $text);
+
+        return trim($normalizedText ?? $text);
+    }
+}


### PR DESCRIPTION
# Custom Pages REST API

Quick and straightforward readonly REST API for custom pages.

## Issue
Fixes #516 

## Endpoints

### Get all Custom Pages

- Method: GET
- Pfad: `/api/v1/custom-pages`

### Get Custom Pages by container

- Method: GET
- Pfad: `/api/v1/custom-pages/container/{containerId}`

### Get a specific Custom Page

- Method: GET
- Pfad: `/api/v1/custom-pages/page/{id}`

## Example-Request

```bash
curl -H "Authorization: Bearer <TOKEN>" \
  "https://example.org/api/v1/custom-pages/page/123"
```

## Example-Response

```json
{
  "id": 123,
  "title": "My custom page",
  "type": 2,
  "target": "SpaceMenu",
  "icon": "fa-file-text-o",
  "sort_order": 100,
  "in_new_window": false,
  "url": "my-custom-page",
  "abstract": "Short description",
  "cssClass": "team-page",
  "page_content": "# Raw content",
  "rendered_content": "<h1>Rendert content</h1><p>… as displayed…</p>",
  "text_content": "Rendert content… as displayed…",
  "visibility": 1,
  "hide_menu": false,
  "page_type": "page",
  "template_id": 0,
  "page_url": "https://example.org/s/space/custom_pages/view?id=123",
  "permalink": "https://example.org/content/perma?id=999",
  "content": {
    "id": 999,
    "guid": "…",
    "created_at": "2026-08-31 10:00:00"
  }
}
```

